### PR TITLE
docs: add perifacode in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | [Grupy-SP](https://www.meetup.com/Grupy-SP/) | Grupo de usuários Python do Estado de São Paulo.    |
 | [GURU-SP](https://www.meetup.com/Guru-SP-Grupo-de-Usuarios-Ruby-de-Sao-Paulo/) | Grupo de Usuários Ruby de São Paulo    |
 | [He4rt Developers](https://heartdevs.com) | A He4rt Developers foi criada com o intuito de guiar quem deseja iniciar na área da programação.    |
+| [perifaCode](https://perifacode.com) | A comunidade de tecnologia de quem é de periferia.    |
 | [PHP Santa Catarina](https://twitter.com/PHP_SC) | O Grupo de Usuários de PHP do Estado de Santa Catarina (PHPSC) é uma entidade aberta de profissionais da área de TI criada em 2007.    |
 | [PHPSP](https://phpsp.org.br) | Grupo de desenvolvedores PHP do estado de São Paulo    |
 | [PyLadies](http://brasil.pyladies.com) | Uma comunidade mundial que foi trazida ao Brasil com o propósito de instigar mais mulheres a entrarem na área tecnológica    |


### PR DESCRIPTION
- Foi adicionada a comunidade [perifaCode](https://perifacode.com) no doc.